### PR TITLE
Minor fix to realtime listener example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ public class RealtimeSample {
             }
         });
 
-        api.getRealtimeService().subscribeTick(Arrays.asList("BTC_JPY")).get();
+        api.getRealtimeService().subscribeTick(Arrays.asList("BTC_JPY"));
 
         TimeUnit.SECONDS.sleep(30L);
 
         api.close();
-
+        System.exit(0); 
     }
 
 }

--- a/README_jp.md
+++ b/README_jp.md
@@ -126,12 +126,12 @@ public class RealtimeSample {
             }
         });
 
-        api.getRealtimeService().subscribeTick(Arrays.asList("BTC_JPY")).get();
+        api.getRealtimeService().subscribeTick(Arrays.asList("BTC_JPY"));
 
         TimeUnit.SECONDS.sleep(30L);
 
         api.close();
-
+        System.exit(0);
     }
 
 }


### PR DESCRIPTION
Same fix on English and Japanese pages.
-Remove unneeded get(). 
-Use System.exit to close down the sample.